### PR TITLE
CVE-2026-54466 | pin websocket-driver@0.7.5

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -47,5 +47,8 @@
       "last 1 safari version"
     ]
   },
-  "packageManager": "yarn@4.0.2"
+  "packageManager": "yarn@4.0.2",
+  "resolutions": {
+    "websocket-driver": "0.7.5"
+  }
 }

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -16971,14 +16971,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"websocket-driver@npm:>=0.5.1, websocket-driver@npm:^0.7.4":
-  version: 0.7.4
-  resolution: "websocket-driver@npm:0.7.4"
+"websocket-driver@npm:0.7.5":
+  version: 0.7.5
+  resolution: "websocket-driver@npm:0.7.5"
   dependencies:
     http-parser-js: "npm:>=0.5.1"
     safe-buffer: "npm:>=5.1.0"
     websocket-extensions: "npm:>=0.1.1"
-  checksum: 5f09547912b27bdc57bac17b7b6527d8993aa4ac8a2d10588bb74aebaf785fdcf64fea034aae0c359b7adff2044dd66f3d03866e4685571f81b13e548f9021f1
+  checksum: 843a3c9f529ce07f2721829f70f62986247525ab22625e857b69da13dc90967bacfe57b85e196801b565cd797e309ddd5b06fa8435732e34e8a8ab6201d7abed
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What

Pins `websocket-driver` to **0.7.5** in `website/` to resolve the critical advisory **GHSA-xv26-6w52-cph6 / CVE-2026-54466** (websocket-driver message corruption via protocol length headers). Mirrors alembic-ui-core#5639.

- `websocket-driver` is a transitive dependency of the Docusaurus docs site (`website/`).
- Pinned via a `resolutions` entry in `website/package.json` and a Yarn 4 lockfile regen (`yarn install --mode=update-lockfile`).
- Diff is 2 files / 8 lines: `0.7.4 → 0.7.5`, no other packages touched. No expected regressions.

Resolves Dependabot alert **twothinkinc/dkron#550**.

## Scope note

This is the minimal, single-CVE pin requested. `website/` and `ui/` carry ~40 other open Dependabot alerts (incl. go.mod `x/crypto` criticals), intentionally **not** addressed here.

> Context for reviewers: this repo is a stale fork of `dkron-io/dkron`; our infra deploys official `distribworks/dkron` release binaries via Ansible (`dkron_version`), not this fork. This pin clears the critical alert but does not affect deployed artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
